### PR TITLE
Allow to access config from plugin object.

### DIFF
--- a/lib/config-plugin.js
+++ b/lib/config-plugin.js
@@ -15,16 +15,24 @@ function loadFile(dir, filename) {
 module.exports = Config
 function Config(options) {
   this.options = options
-
+  this._config = null
 }
+
+Config.prototype.getConfig = function () {
+  if (!this._config) {
+    this._config = _.extend({},
+      loadFile(this.options.dir, "default"),
+      loadFile(this.options.dir, process.env.NODE_ENV),
+      loadFile(this.options.dir, "local")
+    )
+  }
+  return this._config
+}
+
 Config.prototype.apply = function(compiler) {
   // Build the configuration object
   var options = this.options
-  var config = _.extend({},
-    loadFile(options.dir, "default"),
-    loadFile(options.dir, process.env.NODE_ENV),
-    loadFile(options.dir, "local")
-  )
+  var config = this.getConfig()
 
   // Setup a resolver to faux-resolve a request for "config"
   compiler.resolvers.normal.plugin("module", function(request, next) {


### PR DESCRIPTION
Hi,
I added a `getConfig` function to the prototype, so that the config can be accessed
in the webpack config file. This allows to do something like this.

```
var ConfigPlugin = require('webpack-config-plugin');

var configPlugin = new ConfigPlugin({dir: path.join(__dirname, 'config')});

module.exports = {
  output: {
    publicPath: configPlugin.getConfig().assetsEndpoint
  },
  plugins: [
    configPlugin
  ]
};
```

to avoid to have to rewrite the configuration loading logic.

What do you think?
