### PR TITLE
Use merge instead of extend when merging configurations.

### DIFF
--- a/lib/config-plugin.js
+++ b/lib/config-plugin.js
@@ -20,7 +20,7 @@ function Config(options) {
 
 Config.prototype.getConfig = function () {
   if (!this._config) {
-    this._config = _.extend({},
+    this._config = _.merge({},
       loadFile(this.options.dir, "default"),
       loadFile(this.options.dir, process.env.NODE_ENV),
       loadFile(this.options.dir, "local")


### PR DESCRIPTION
`_.extend` is not recursive, therefore

``` js
_.extend({
  config: {
    nested: "default",
    other: "foo"
  }
}, {
  config: {
    nested: "override"
  }
})
```

will result in

```
 {
  config: {
    nested: "override"
  }
}
```

Using `_.merge` should make this kind of overrides easier.
